### PR TITLE
Extxyz support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     reviewers:
-      - "simonesturniolo"
+      - "jkshenton"
     labels:
       - "dependencies"
     commit-message:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@ccp-nc/crystvis-js": "^0.6.0",
+        "@ccp-nc/crystvis-js": "^0.6.1",
         "@nivo/line": "^0.99.0",
         "@popperjs/core": "^2.11.8",
         "color-scales": "^3.0.2",
@@ -2080,20 +2080,20 @@
       }
     },
     "node_modules/@ccp-nc/crystvis-js": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@ccp-nc/crystvis-js/-/crystvis-js-0.6.0.tgz",
-      "integrity": "sha512-ARfMUJh/o25z82YEdhQ+hjAB1fota3g7ii+pzMlJXt9Xc+Ow744l1/smV6C/VvXPQTyAf/mlGfUsFVZqaW6oPQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@ccp-nc/crystvis-js/-/crystvis-js-0.6.1.tgz",
+      "integrity": "sha512-5BgPo9FSMEbKyh8fVVmD2o/znzAXXAAMtlVFdkK+TwGr2jIpYgEhBckFZ1tkXeCmdHO4zCo8nwWXkWqhgE1bEA==",
       "license": "MIT",
       "dependencies": {
         "@ccp-nc/crystcif-parse": "^0.2.9",
         "@jkshenton/three-bmfont-text": "^4.0.1",
         "buffer": "^6.0.3",
-        "chroma-js": "^3.1.2",
+        "chroma-js": "^3.2.0",
         "isosurface": "^1.0.0",
         "jquery": "^3.7.1",
         "load-bmfont": "^1.4.2",
         "lodash": "^4.17.21",
-        "mathjs": "^14.5.3",
+        "mathjs": "^14.9.1",
         "three": "^0.178.0",
         "yargs-parser": "^22.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": ".",
   "type": "module",
   "dependencies": {
-    "@ccp-nc/crystvis-js": "^0.6.0",
+    "@ccp-nc/crystvis-js": "^0.6.1",
     "@nivo/line": "^0.99.0",
     "@popperjs/core": "^2.11.8",
     "color-scales": "^3.0.2",

--- a/src/core/sidebars/MVSidebarLoad.jsx
+++ b/src/core/sidebars/MVSidebarLoad.jsx
@@ -33,7 +33,7 @@ import { tooltip_molecular_crystal, tooltip_nmr_active, tooltip_vdw_scaling } fr
 import MVRange from '../../controls/MVRange';
 
 // Accepted file formats
-const file_formats = ['.cif', '.xyz', '.magres', '.cell'];
+const file_formats = ['.cif', '.xyz', '.extxyz', '.magres', '.cell'];
 
 function MVSidebarLoad(props) {
 


### PR DESCRIPTION
Update to crystvis-js 0.6.1 which adds support for extxyz files, including reading in MS and EFG tensors from them.

Update to allowed file types to include extxyz. 